### PR TITLE
Add test cases for multiple interpolations

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,8 @@
   "scripts": {
     "pretest": "npm run compile",
     "test": "mocha --reporter spec --full-trace lib/test/tests.js",
-    "posttest": "npm run lint",
     "compile": "tsc",
-    "lint": "tslint -c tslint.json test/**/*.ts; tslint src/**/*.ts"
+    "lint": "tslint --project tslint.json --type-check -c tslint.json test/**/*.ts; tslint --project tslint.json --type-check src/**/*.ts"
   },
   "repository": {
     "type": "git",
@@ -30,7 +29,12 @@
   },
   "devDependencies": {
     "@types/chai": "^3.4.35",
+    "@types/graphql": "^0.9.0",
     "@types/mocha": "^2.2.40",
-    "es6-promise": "^4.1.0"
+    "chai": "^3.5.0",
+    "es6-promise": "^4.1.0",
+    "mocha": "^3.2.0",
+    "tslint": "^5.0.0",
+    "typescript": "^2.2.2"
   }
 }

--- a/src/extractFromAST.ts
+++ b/src/extractFromAST.ts
@@ -90,7 +90,7 @@ export default class ExtractFromAST {
         fragmentNames[selection.name.value] = 1;
         const innerFragmentNames = ExtractFromAST.getFragmentNames(
           fragmentDefinitions[selection.name.value].selectionSet,
-          document
+          document,
         );
         fragmentNames = _.merge(fragmentNames, innerFragmentNames);
       } else if (ExtractFromAST.isInlineFragment(selection) || ExtractFromAST.isField(selection)) {

--- a/src/extractFromJS.ts
+++ b/src/extractFromJS.ts
@@ -16,8 +16,20 @@ export default class ExtractFromJS {
   }
 
   public static eliminateInterpolations(templateLiteralContents: string): string {
-    const regex = /\$\{[\s\S]+?\}/mg;
+    const regex = /\$\{[\s\S]+?\}\n?/gm;
 
-    return templateLiteralContents.replace(regex, '');
+    return templateLiteralContents.replace(regex, '').trim();
+  }
+
+  public static getInterpolations(templateLiteralContents: string): string[] {
+    const regex = /\$\{[\s\S]+?\}/gm;
+
+    let match;
+    const matches = [];
+    while ((match = regex.exec(templateLiteralContents)) != null) {
+      matches.push(match[0]);
+    }
+
+    return matches;
   }
 }

--- a/test/extractFromJS.ts
+++ b/test/extractFromJS.ts
@@ -4,7 +4,7 @@ const { assert } = chai;
 import ExtractFromJS from '../src/extractFromJS';
 
 describe('extractFromJS', () => {
-  it('should be able to find tagged strings inside JS', () => {
+  it('findTaggedTemplateLiteralsInJS should be able to find tagged strings inside JS', () => {
     const jsFile = `
       // Single line
       const query = gql\`xxx\`;
@@ -25,19 +25,68 @@ y\`;
     ]);
   });
 
-  it('should eliminate interpolations', () => {
-    const contents = `
-      {
-        a { b ...c }
-      }
-\${c}
-    `;
+  describe('eliminateInterpolations', () => {
+    it('eliminates a single interpolation', () => {
+      const contents = `
+        {
+          a { b ...c }
+        }
+        \${c}
+      `.trim();
 
-    assert.deepEqual(ExtractFromJS.eliminateInterpolations(contents), `
-      {
-        a { b ...c }
-      }
+      assert.deepEqual(ExtractFromJS.eliminateInterpolations(contents), `
+        {
+          a { b ...c }
+        }
+      `.trim());
+    });
 
-    `);
+    it('eliminates multiple interpolations', () => {
+      const contents = `
+        {
+          a { b ...c }
+        }
+        \${c}
+        \${d}
+      `.trim();
+
+      assert.deepEqual(ExtractFromJS.eliminateInterpolations(contents), `
+        {
+          a { b ...c }
+        }
+      `.trim());
+    });
+  });
+
+  describe('getInterpolations', () => {
+    it('should return interpolations for a single interpolation', () => {
+      const contents = `
+        {
+          a { b ...c }
+        }
+        \${c}
+      `;
+
+      const interpolations = ExtractFromJS.getInterpolations(contents);
+      const expected = ['${c}'];
+
+      assert.sameDeepMembers(interpolations, expected);
+    });
+
+    it('should return interpolations for multiple interpolations', () => {
+      const contents = `
+        {
+          a { b ...c }
+        }
+        \${c}
+        \${d}
+        \${e}
+      `;
+
+      const interpolations = ExtractFromJS.getInterpolations(contents);
+      const expected = ['${c}', '${d}', '${e}'];
+
+      assert.sameDeepMembers(interpolations, expected);
+    });
   });
 });

--- a/test/queryTransformers.ts
+++ b/test/queryTransformers.ts
@@ -17,7 +17,7 @@ describe('query transformers', () => {
     const assertTransform = (inputQuery: DocumentNode, expected: DocumentNode) => {
       assert.equal(
         print(addTypenameTransformer(inputQuery)),
-        print(expected)
+        print(expected),
       );
     };
 

--- a/tslint.json
+++ b/tslint.json
@@ -18,7 +18,6 @@
     "interface-name": false,
     "jsdoc-format": true,
     "label-position": true,
-    "label-undefined": true,
     "max-line-length": [
       true,
       140
@@ -44,9 +43,7 @@
       "trace"
     ],
     "no-construct": true,
-    "no-constructor-vars": true,
     "no-debugger": true,
-    "no-duplicate-key": true,
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
@@ -57,7 +54,6 @@
     "no-shadowed-variable": true,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
-    "no-unreachable": true,
     "no-unused-expression": true,
     "no-unused-variable": true,
     "no-use-before-declare": true,
@@ -118,9 +114,6 @@
         "property-declaration": "space",
         "variable-declaration": "space"
       }
-    ],
-    "use-strict": [
-      false
     ],
     "variable-name": [
       true,


### PR DESCRIPTION
- Add test cases for multiple interpolations in a query document
- Allow getting interpolations in addition to eliminating interpolations